### PR TITLE
Return a HTTP 201 response when there is no content to provide

### DIFF
--- a/slash_slack/slash_slack.py
+++ b/slash_slack/slash_slack.py
@@ -167,6 +167,9 @@ class SlashSlack:
             and self.commands[command].acknowledge_response is not None
         ):
             kwargs["content"] = self.commands[command].acknowledge_response
+
+        if "content" not in kwargs:
+            return Response(status_code=201)
         return JSONResponse(**kwargs)
 
     def get_fast_api(self):


### PR DESCRIPTION
Return a HTTP 201 response when there is no content to prevent the unnecessary acknowledgement response.

This also prevents `JSONResponse` being called with no content that raises an exception in the form 
```
JSONResponse.__init__() missing 1 required positional argument: 'content' 
```

Resolves https://github.com/henryivesjones/slash-slack/issues/5